### PR TITLE
Menu-console (Chest, Stats and more)

### DIFF
--- a/src/Consoles/MainConsole.cs
+++ b/src/Consoles/MainConsole.cs
@@ -16,11 +16,15 @@ namespace ShadowsOfShadows.Consoles
 
 	public class MainConsole : Console
 	{
+	    public Player Player { get; private set; }
+
 		private Room testRoom = new Room (new[]{ new TestEntity () });
 		public MainConsole (int width, int height) : base(width, height)
 		{
 			testRoom.Entities.First ().Renderable = new ConsoleRenderable ('A');
 			testRoom.Entities.First ().Transform.Position = new Point (1,1);
+
+		    Player = new Player("Player");
 		}
 
 		public override void Draw (System.TimeSpan delta)

--- a/src/Consoles/MenuConsole.cs
+++ b/src/Consoles/MenuConsole.cs
@@ -98,9 +98,12 @@ namespace ShadowsOfShadows.Consoles
             );
         }
 
-        public void OpenChest(Chest chest)
+        public ChestMessage OpenChest(Chest chest)
         {
-            throw new NotImplementedException();
+            var message = new ChestMessage(chest);
+            PrintMessageAndWait(message);
+            message.PostProcessing = msg => PrintPlayerStats();
+            return message;
         }
     }
 }

--- a/src/Consoles/MenuConsole.cs
+++ b/src/Consoles/MenuConsole.cs
@@ -74,7 +74,7 @@ namespace ShadowsOfShadows.Consoles
                     //TODO: Show settings (should we have any)
                     break;
                 case MainMenuOptions.CloseMenu:
-                    PrintMessage("");
+                    PrintPlayerStats();
                     break;
                 case MainMenuOptions.Quit:
                     SadConsole.Game.Instance.Exit();
@@ -84,11 +84,23 @@ namespace ShadowsOfShadows.Consoles
             }
         }
 
-     public void OpenChest(Chest chest)
-     {
-            throw new NotImplementedException();
-      }
+        private void PrintPlayerStats()
+        {
+            PrintMessage(
+                "STATS\n\n" +
+                "HP       " + Screen.MainConsole.Player.Health + "\n" +
+                "Mana     " + Screen.MainConsole.Player.Mana + "\n" +
+                "AP       " + Screen.MainConsole.Player.AttackPower + "\n" +
+                "MP       " + Screen.MainConsole.Player.MagicPower + "\n" +
+                "DP       " + Screen.MainConsole.Player.DefencePower + "\n" +
+                "Level    " + Screen.MainConsole.Player.Level + "\n" +
+                "\n"
+            );
+        }
 
+        public void OpenChest(Chest chest)
+        {
+            throw new NotImplementedException();
+        }
     }
 }
-

--- a/src/Consoles/MenuConsole.cs
+++ b/src/Consoles/MenuConsole.cs
@@ -40,9 +40,9 @@ namespace ShadowsOfShadows.Consoles
 
         protected override void PrintMessage(Message message)
         {
-            if (message is QuestionMessage)
+            if (message.IsInstanceOfGenericType(typeof(ChoiceMessage<>)))
             {
-                var qm = (QuestionMessage) message;
+                dynamic qm = message;
                 qm.Rows = qm.AnswersCount;
             }
             base.PrintMessage(message);

--- a/src/Consoles/MenuConsole.cs
+++ b/src/Consoles/MenuConsole.cs
@@ -43,7 +43,7 @@ namespace ShadowsOfShadows.Consoles
             if (message is QuestionMessage)
             {
                 var qm = (QuestionMessage) message;
-                qm.Rows = qm.AnswerCount;
+                qm.Rows = qm.AnswersCount;
             }
             base.PrintMessage(message);
         }
@@ -84,7 +84,7 @@ namespace ShadowsOfShadows.Consoles
             }
         }
 
-        private void PrintPlayerStats()
+        public void PrintPlayerStats()
         {
             PrintMessage(
                 "STATS\n\n" +

--- a/src/Consoles/Messages.cs
+++ b/src/Consoles/Messages.cs
@@ -6,13 +6,17 @@ using System.Globalization;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using SadConsole.GameHelpers;
+using ShadowsOfShadows.Entities;
 using ShadowsOfShadows.Helpers;
+using ShadowsOfShadows.Items;
 using Keyboard = SadConsole.Input.Keyboard;
 
 namespace ShadowsOfShadows.Consoles
 {
     public abstract class Message
     {
+        public const int PointerGlyph = 26;
+
         public abstract GameObject Text { get; }
         public abstract GameObject WaitPointer { get; }
         public abstract List<GameObject> Other { get; }
@@ -75,6 +79,90 @@ namespace ShadowsOfShadows.Consoles
         }
     }
 
+    public class ChoiceMessage<T> : Message
+    {
+        protected List<Tuple<T, string>> Answers;
+        public int AnswersCount => Answers.Count;
+
+        public int Rows { get; set; } = 1;
+
+        public override GameObject Text { get; }
+        public override GameObject WaitPointer { get; }
+        public override List<GameObject> Other { get; }
+
+        private int pointerIndex;
+        protected int PointerIndex
+        {
+            get { return pointerIndex; }
+            set
+            {
+                pointerIndex = value % Positions.Count;
+                if (pointerIndex < 0) pointerIndex += Positions.Count;
+                WaitPointer.Position = Positions[pointerIndex] + new Point(-1, 0);
+            }
+        }
+
+        protected List<Point> Positions = new List<Point>();
+
+        public ChoiceMessage(IEnumerable<Tuple<T, string>> answers, string question = null)
+        {
+            Answers = new List<Tuple<T, string>>(answers);
+            WaitPointer = ConsoleObjects.CreateFromGlyph(PointerGlyph);
+            Other = new List<GameObject>();
+            if (question != null)
+                Text = ConsoleObjects.CreateFromString(question);
+        }
+
+        public override void Create(MessageConsole console)
+        {
+            Other.Clear();
+            Other.AddRange(Answers.Select(t => ConsoleObjects.CreateFromString(t.Item2)));
+
+            ComputePositions(console);
+
+            for (var i = 0; i < Other.Count; i++)
+                Other[i].Position = Positions[i];
+
+            PointerIndex = 0;
+
+            Text.Position = console.Position + new Point(1, 1);
+        }
+
+        private void ComputePositions(MessageConsole console)
+        {
+            var columns = (int) Math.Ceiling(Answers.Count * 1.0 / Rows);
+            var last = 1;
+            for (var i = 0; i < columns; i++)
+            {
+                for (var j = 0; j < Rows && i * Rows + j < Answers.Count; j++)
+                    Positions.Add(console.Position + new Point(last, j + 1 + (Text == null ? 0 : 2)));
+
+                var maxLegth = 0;
+                for (var j = 0; j < Rows && i * Rows + j < Answers.Count; j++)
+                    maxLegth = Math.Max(maxLegth, Answers[i * Rows + j].Item2.Length);
+                last += maxLegth + 2;
+            }
+        }
+
+        public override void ProcessKeyboard(Keyboard info)
+        {
+            base.ProcessKeyboard(info);
+            MovePointer(info);
+        }
+
+        protected void MovePointer(Keyboard info)
+        {
+            if (info.IsKeyPressed(Keys.Left))
+                PointerIndex -= Rows;
+            else if (info.IsKeyPressed(Keys.Right))
+                PointerIndex += Rows;
+            else if (info.IsKeyPressed(Keys.Down))
+                PointerIndex += 1;
+            else if (info.IsKeyPressed(Keys.Up))
+                PointerIndex -= 1;
+        }
+    }
+
     [AttributeUsage(AttributeTargets.All)]
     public class DisplayAttribute : Attribute
     {
@@ -86,109 +174,38 @@ namespace ShadowsOfShadows.Consoles
         }
     }
 
-    public class QuestionMessage : Message
+    public class QuestionMessage : ChoiceMessage<Enum>
     {
-        private List<Tuple<Enum, string>> answers;
-
-        public int Rows { get; set; } = 3;
-
-        public int AnswerCount { get; }
-
         public QuestionMessage(Type answersType, string question = null)
-        {
-            answers = answersType.GetEnumValues()
+            :base(answersType.GetEnumValues()
                 .Cast<Enum>()
                 .Select(@enum => new Tuple<Enum, string>(@enum, @enum.GetAttributeOfType<DisplayAttribute>()?.Title))
                 .Where(tp => tp.Item2 != null)
-                .ToList();
-            AnswerCount = answers.Count;
-
-            if (question != null)
-            {
-                Text = ConsoleObjects.CreateFromString(question);
-                Rows = 2;
-            }
-        }
-
-        public override GameObject Text { get; } = null;
-
-        private GameObject waitPointer;
-        public override GameObject WaitPointer => waitPointer;
-
-        private int pointerIndex;
-
-        private int PointerIndex
+                , question)
         {
-            get { return pointerIndex; }
-            set
-            {
-                pointerIndex = value % positions.Count;
-                if (pointerIndex < 0) pointerIndex += positions.Count;
-                waitPointer.Position = positions[pointerIndex] + new Point(-1, 0);
-            }
+            if (question != null)
+                Rows = 2;
+            else
+                Rows = 3;
         }
 
-        private List<GameObject> consoleObjects = new List<GameObject>();
-        private List<Point> positions = new List<Point>();
-        public override List<GameObject> Other => consoleObjects;
-
-        private Enum result;
-        public Enum Result => result;
+        public Enum Result { get; private set; }
 
         public Enum DefaultAnswer { get; set; }
-
-        public override void Create(MessageConsole console)
-        {
-            waitPointer = ConsoleObjects.CreateFromGlyph(26);
-            consoleObjects = answers.Select(t => ConsoleObjects.CreateFromString(t.Item2)).ToList();
-
-            ComputePositions(console);
-
-            for (var i = 0; i < consoleObjects.Count; i++)
-                consoleObjects[i].Position = positions[i];
-
-            PointerIndex = 0;
-
-            Text.Position = console.Position + new Point(1, 1);
-        }
-
-        private void ComputePositions(MessageConsole console)
-        {
-            var columns = (int) Math.Ceiling(answers.Count * 1.0 / Rows);
-            var last = 1;
-            for (var i = 0; i < columns; i++)
-            {
-                for (var j = 0; j < Rows && i * Rows + j < answers.Count; j++)
-                    positions.Add(console.Position + new Point(last, j + 1 + (Text == null ? 0 : 2)));
-
-                var maxLegth = 0;
-                for (var j = 0; j < Rows && i * Rows + j < answers.Count; j++)
-                    maxLegth = Math.Max(maxLegth, answers[i * Rows + j].Item2.Length);
-                last += maxLegth + 2;
-            }
-        }
 
         public override void ProcessKeyboard(Keyboard info)
         {
             base.ProcessKeyboard(info);
-            if (info.IsKeyPressed(Keys.Left))
-                PointerIndex -= Rows;
-            else if (info.IsKeyPressed(Keys.Right))
-                PointerIndex += Rows;
-            else if (info.IsKeyPressed(Keys.Down))
-                PointerIndex += 1;
-            else if (info.IsKeyPressed(Keys.Up))
-                PointerIndex -= 1;
 
             if (info.IsKeyPressed(Keys.Enter) || info.IsKeyPressed(Keys.Space))
             {
-                result = answers[PointerIndex].Item1;
+                Result = Answers[PointerIndex].Item1;
                 Finished = true;
             }
 
             if (info.IsKeyPressed(Keys.Escape) && DefaultAnswer != null)
             {
-                result = DefaultAnswer;
+                Result = DefaultAnswer;
                 Finished = true;
             }
         }

--- a/src/Consoles/Messages.cs
+++ b/src/Consoles/Messages.cs
@@ -96,11 +96,21 @@ namespace ShadowsOfShadows.Consoles
             get { return pointerIndex; }
             set
             {
-                pointerIndex = value % Positions.Count;
-                if (pointerIndex < 0) pointerIndex += Positions.Count;
-                WaitPointer.Position = Positions[pointerIndex] + new Point(-1, 0);
+                if (Positions.Count == 0)
+                {
+                    pointerIndex = 0;
+                    WaitPointer.IsVisible = false;
+                }
+                else
+                {
+                    pointerIndex = value % Positions.Count;
+                    if (pointerIndex < 0) pointerIndex += Positions.Count;
+                    WaitPointer.Position = Positions[pointerIndex] + new Point(-1, 0);
+                }
             }
         }
+
+        public int StartIndex { get; set; } = 0;
 
         protected List<Point> Positions = new List<Point>();
 
@@ -123,7 +133,7 @@ namespace ShadowsOfShadows.Consoles
             for (var i = 0; i < Other.Count; i++)
                 Other[i].Position = Positions[i];
 
-            PointerIndex = 0;
+            PointerIndex = StartIndex;
 
             Text.Position = console.Position + new Point(1, 1);
         }
@@ -230,6 +240,10 @@ namespace ShadowsOfShadows.Consoles
             {
                 ProcessItemWithEquipment(Answers[PointerIndex].Item1);
             }
+            if (info.IsKeyPressed(Keys.Escape))
+            {
+                Finished = true;
+            }
         }
 
         private void ProcessItemWithEquipment(Item item)
@@ -266,7 +280,8 @@ namespace ShadowsOfShadows.Consoles
         {
             var newMessage = Screen.MenuConsole.OpenChest(Chest);
             this.PostProcessing = null;
-            newMessage.PointerIndex = this.PointerIndex;
+            newMessage.StartIndex = this.PointerIndex;
+            Finished = true;
         }
     }
 }

--- a/src/Consoles/Screen.cs
+++ b/src/Consoles/Screen.cs
@@ -2,6 +2,9 @@
 using System.ComponentModel;
 using SadConsole.Input;
 using ShadowsOfShadows.Consoles;
+using ShadowsOfShadows.Entities;
+using ShadowsOfShadows.Items;
+using ShadowsOfShadows.Renderables;
 
 namespace ShadowsOfShadows
 {
@@ -18,6 +21,31 @@ namespace ShadowsOfShadows
         [Display("Do zobaczenia...")]
         DoZo
 
+    }
+
+    public class TestItem : Item
+    {
+        public override AllowedItem Allowed { get; }
+        public override bool IsLike(Item item)
+        {
+            return item is TestItem;
+        }
+
+        private string str;
+
+        public TestItem(AllowedItem allowed)
+        {
+            Allowed = allowed;
+            if (allowed == AllowedItem.Multiple)
+                str = "MultipleItem";
+            else
+                str = "SingleItem";
+        }
+
+        public override string ToString()
+        {
+            return str;
+        }
     }
 
     public class Screen : SadConsole.ConsoleContainer
@@ -41,7 +69,18 @@ namespace ShadowsOfShadows
 
             MessageConsole.PrintMessageAndWait("This is a message\nAnd with line breaks");
             MessageConsole.AskQuestion("Co mi powiesz?", typeof(TestEnum)).PostProcessing =
-                (m) => MenuConsole.OpenMainMenu();
+                (m) =>
+                {
+                    var chest = new Chest(new ConsoleRenderable('c'), 0,
+                        new[]
+                        {
+                            new TestItem(AllowedItem.Multiple), new TestItem(AllowedItem.Multiple),
+                            new TestItem(AllowedItem.Single), new TestItem(AllowedItem.Single)
+                        });
+                    MenuConsole.OpenChest(chest);
+                };
+
+
         }
 
         public override bool ProcessKeyboard(Keyboard state)

--- a/src/Entities/Chest.cs
+++ b/src/Entities/Chest.cs
@@ -9,20 +9,17 @@ namespace ShadowsOfShadows.Entities
 {
     public class Chest : Openable
     {
-        List<Item> Items { get; set; }
+        public List<Item> Items { get; }
 
-        public Chest(IRenderable rendarable, int lockDificulty, List<Item> items) : base(rendarable, lockDificulty)
+        public Chest(IRenderable rendarable, int lockDificulty, IEnumerable<Item> items) : base(rendarable, lockDificulty)
         {
-            Items = items;
+            Items = new List<Item>(items);
         }
 
         public override void Interact()
         {
-            if(CheckOpened())
-            {
-                //TODO: change current console to menu console
+            if (CheckOpened())
                 Screen.MenuConsole.OpenChest(this);
-            }
         }
     }
 }

--- a/src/Helpers/GenericsHelper.cs
+++ b/src/Helpers/GenericsHelper.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace ShadowsOfShadows.Helpers
+{
+    public static class GenericsHelper
+    {
+        public static bool IsInstanceOfGenericType(this object instance, Type genericType)
+        {
+            var type = instance.GetType();
+            while (type != null)
+            {
+                if (type.IsGenericType &&
+                    type.GetGenericTypeDefinition() == genericType)
+                {
+                    return true;
+                }
+                type = type.BaseType;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Helpers/PopularQuestions.cs
+++ b/src/Helpers/PopularQuestions.cs
@@ -1,0 +1,12 @@
+﻿using ShadowsOfShadows.Consoles;
+
+namespace ShadowsOfShadows.Helpers
+{
+    public enum YesNoQuestion
+    {
+        [Display("No")]
+        No,
+        [Display("Yes")]
+        Yes
+    }
+}

--- a/src/Items/AllowedItem.cs
+++ b/src/Items/AllowedItem.cs
@@ -1,0 +1,8 @@
+﻿namespace ShadowsOfShadows.Items
+{
+    public enum AllowedItem
+    {
+        Multiple,
+        Single
+    }
+}

--- a/src/Items/Item.cs
+++ b/src/Items/Item.cs
@@ -2,11 +2,13 @@
 
 namespace ShadowsOfShadows.Items
 {
-	public class Item
+	public abstract class Item
 	{
-		public Item()
-		{
-			
-		}
+	    public abstract AllowedItem Allowed { get; }
+
+	    public virtual bool IsLike(Item item)
+	    {
+	        return false;
+	    }
 	}
 }

--- a/src/Renderables/ConsoleRenderable.cs
+++ b/src/Renderables/ConsoleRenderable.cs
@@ -7,11 +7,15 @@ namespace ShadowsOfShadows.Renderables
 {
 	public class ConsoleRenderable : IRenderable
 	{
-		public ConsoleRenderable ( char symbol)
+		public ConsoleRenderable (char symbol)
 		{
 			ConsoleObject = ConsoleObjects.CreateFromChar(symbol);
 		}
 
+	    public ConsoleRenderable(int glyph)
+	    {
+	        ConsoleObject = ConsoleObjects.CreateFromGlyph(glyph);
+	    }
 
 		public GameObject ConsoleObject { get;} 
 	}

--- a/src/ShadowsOfShadows.csproj
+++ b/src/ShadowsOfShadows.csproj
@@ -30,6 +30,7 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="SadConsole">
       <HintPath>packages\SadConsole.6.1.3\lib\net\SadConsole.dll</HintPath>
     </Reference>
@@ -41,6 +42,7 @@
   <ItemGroup>
     <Compile Include="Consoles\Messages.cs" />
     <Compile Include="Helpers\EnumHelper.cs" />
+    <Compile Include="Helpers\GenericsHelper.cs" />
     <Compile Include="Helpers\PopularQuestions.cs" />
     <Compile Include="Items\AllowedItem.cs" />
     <Compile Include="Program.cs" />

--- a/src/ShadowsOfShadows.csproj
+++ b/src/ShadowsOfShadows.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,6 +41,8 @@
   <ItemGroup>
     <Compile Include="Consoles\Messages.cs" />
     <Compile Include="Helpers\EnumHelper.cs" />
+    <Compile Include="Helpers\PopularQuestions.cs" />
+    <Compile Include="Items\AllowedItem.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Entities\Entity.cs" />


### PR DESCRIPTION
Zrobiłem, że kiedy nie korzystamy z MenuConsole to wyświetlają się statystyki gracza (na razie ręcznie się to wywołuje, ale można pomyśleć nad wywoływaniem na zmianę `IsActive`)

Zrobiłem refactor `QuestionMessage` do `ChoiceMessage<T>`, żeby łatwiej zrobić `ChestMessage`, który też zaimplementowałem.

@dkaluza Dokładam ci roboty, dodając dwa nowe pola do `Item`. `Allowed` ma być ustawiony na `Single` dla wszystkich `Wearable`, a na `Multiple` dla pozostałych. `IsLike` zwraca true dla elementów tego samego typu, których nie można mieć wiele na raz.

Rzućcie okiem, zbudujcie, przetestujcie, zatwierdźcie i zmergujcie :smiley: