### PR TITLE
Implement MessageConsole.PrintWithTimeout(msg, milliseconds)

### DIFF
--- a/src/Consoles/MessageConsole.cs
+++ b/src/Consoles/MessageConsole.cs
@@ -27,7 +27,7 @@ namespace ShadowsOfShadows.Consoles
             this.Position = new Point(posX, poxY);
         }
 
-        public void PrintMessage(string message)
+        protected void PrintMessage(string message)
         {
             PrintMessage(new SimpleMessage(message));
         }
@@ -42,6 +42,11 @@ namespace ShadowsOfShadows.Consoles
             CurrentMessage = message;
         }
 
+        public void PrintMessageWithTimeout(string message, int milliseconds)
+        {
+            PrintMessageAndWait(new TimeoutMessage(message, milliseconds));
+        }
+        
         public void PrintMessageAndWait(string message)
         {
             PrintMessageAndWait(new WaitMessage(message));

--- a/src/Consoles/MessageConsole.cs
+++ b/src/Consoles/MessageConsole.cs
@@ -14,6 +14,7 @@ namespace ShadowsOfShadows.Consoles
     {
         public bool IsActive { get; set; }
         public bool ClearInactive { get; set; } = true;
+        public bool Blocking { get; private set; } = true;
 
         protected Message CurrentMessage;
 
@@ -40,6 +41,7 @@ namespace ShadowsOfShadows.Consoles
             if (message.WaitPointer != null) ConsoleObjects.Add(message.WaitPointer);
             if (message.Other != null) ConsoleObjects.AddRange(message.Other);
             CurrentMessage = message;
+            if (message.NonBlocking) Blocking = false;
         }
 
         public void PrintMessageWithTimeout(string message, int milliseconds)
@@ -97,6 +99,7 @@ namespace ShadowsOfShadows.Consoles
                 CurrentMessage.ProcessKeyboard(info);
                 if (CurrentMessage.Finished)
                 {
+                    if (CurrentMessage.NonBlocking) Blocking = true;
                     CurrentMessage.OnPostProcessing();
                     wait = false;
                     if (MessageQueue.Count > 0)
@@ -111,7 +114,7 @@ namespace ShadowsOfShadows.Consoles
                     }
                 }
             }
-            return true;
+            return Blocking;
         }
 
         public override void Update(TimeSpan delta)

--- a/src/Consoles/Messages.cs
+++ b/src/Consoles/Messages.cs
@@ -21,6 +21,8 @@ namespace ShadowsOfShadows.Consoles
         public abstract List<GameObject> Other { get; }
         public bool Finished { get; protected set; }
 
+        public virtual bool NonBlocking { get; } = false;
+
         public Action<Message> PostProcessing { get; set; }
 
         public abstract void Create(MessageConsole console);
@@ -361,6 +363,8 @@ namespace ShadowsOfShadows.Consoles
         public override GameObject Text { get; }
         public override GameObject WaitPointer { get; }
         public override List<GameObject> Other { get; }
+
+        public override bool NonBlocking { get; } = true;
 
         private Timer timer;
 

--- a/src/Consoles/Messages.cs
+++ b/src/Consoles/Messages.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Timers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using SadConsole.GameHelpers;
@@ -338,7 +339,7 @@ namespace ShadowsOfShadows.Consoles
             {
                 consumable.Use();
                 Screen.MainConsole.Player.Equipment.Remove(consumable);
-                Screen.MessageConsole.PrintMessage($"{consumable} consumed.");
+                Screen.MessageConsole.PrintMessageWithTimeout($"{consumable} consumed.", TimeoutMessage.GENERAL_TIMEOUT);
                 ResetView();
             }
         }
@@ -349,6 +350,35 @@ namespace ShadowsOfShadows.Consoles
             PostProcessing = null;
             newMessage.StartIndex = PointerIndex;
             Finished = true;
+        }
+    }
+
+    public class TimeoutMessage : Message
+    {
+        public const int GENERAL_TIMEOUT = 3000; //3 seconds
+        public const int SHORT_TIMEOUT = 2000;   //2 seconds
+
+        public override GameObject Text { get; }
+        public override GameObject WaitPointer { get; }
+        public override List<GameObject> Other { get; }
+
+        private Timer timer;
+
+        public TimeoutMessage(string message, int milliseconds)
+        {
+            Text = ConsoleObjects.CreateFromString(message);
+            WaitPointer = null;
+            Other = null;
+
+            timer = new Timer(milliseconds);
+            timer.AutoReset = false;
+            timer.Elapsed += (sender, args) => Finished = true;
+        }
+
+        public override void Create(MessageConsole console)
+        {
+            Text.Position = console.Position + new Point(1, 1);
+            timer.Start();
         }
     }
 }

--- a/src/Consoles/Screen.cs
+++ b/src/Consoles/Screen.cs
@@ -82,11 +82,18 @@ namespace ShadowsOfShadows
         {
             base.Update(delta);
             if (MessageConsole.IsActive)
+            {
                 MessageConsole.Update(delta);
-            else if (MenuConsole.IsActive)
+                if (MessageConsole.Blocking)
+                    return;
+            }
+            if (MenuConsole.IsActive)
+            {
                 MenuConsole.Update(delta);
-            else 
-                MainConsole.Update(delta);
+                if (MenuConsole.Blocking)
+                    return;
+            }
+            MainConsole.Update(delta);
         }
 
         public override void Draw(TimeSpan delta)

--- a/src/Entities/Character.cs
+++ b/src/Entities/Character.cs
@@ -5,6 +5,8 @@ using ShadowsOfShadows.Items;
 using ShadowsOfShadows.Physics;
 using ShadowsOfShadows.Renderables;
 using System.Linq;
+using System.Threading;
+using ShadowsOfShadows.Consoles;
 
 namespace ShadowsOfShadows.Entities
 {
@@ -123,7 +125,9 @@ namespace ShadowsOfShadows.Entities
             int previousHP = character.Health;
             double sample = rnd.Sample();
             character.TakeDamage((int)(AttackPower * sample));
-            Screen.MessageConsole.PrintMessage(Name + " dealt " + (previousHP - character.Health) + " damage to " + character.Name);
+            Screen.MessageConsole.PrintMessageWithTimeout(
+                Name + " dealt " + (previousHP - character.Health) + " damage to " + character.Name,
+                TimeoutMessage.SHORT_TIMEOUT);
         }
 
         public void TakeDamage(int amount)

--- a/src/Entities/Openable.cs
+++ b/src/Entities/Openable.cs
@@ -1,4 +1,5 @@
-﻿using ShadowsOfShadows.Renderables;
+﻿using ShadowsOfShadows.Consoles;
+using ShadowsOfShadows.Renderables;
 
 namespace ShadowsOfShadows.Entities
 {
@@ -21,12 +22,12 @@ namespace ShadowsOfShadows.Entities
             if (Screen.MainConsole.Player.UnlockingSkillLevel >= LockDificulty)
             {
                 LockDificulty = 0;
-                Screen.MessageConsole.PrintMessage("Lockpicking succeeded");
+                Screen.MessageConsole.PrintMessageWithTimeout("Lockpicking succeeded", TimeoutMessage.GENERAL_TIMEOUT);
                 return true;
             }
             else
             {
-                Screen.MessageConsole.PrintMessage("Lockpicking failed");
+                Screen.MessageConsole.PrintMessageWithTimeout("Lockpicking failed", TimeoutMessage.GENERAL_TIMEOUT);
                 return false;
             }
         }
@@ -39,7 +40,7 @@ namespace ShadowsOfShadows.Entities
                 return true;
             else
             {
-                Screen.MessageConsole.PrintMessage("Target is locked");
+                Screen.MessageConsole.PrintMessageWithTimeout("Target is locked", TimeoutMessage.GENERAL_TIMEOUT);
                 return false;
             }
         }

--- a/src/Entities/Switch.cs
+++ b/src/Entities/Switch.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ShadowsOfShadows.Consoles;
 using ShadowsOfShadows.Renderables;
 
 namespace ShadowsOfShadows.Entities
@@ -21,7 +22,7 @@ namespace ShadowsOfShadows.Entities
         public void Interact()
         {
             Value = !Value;
-			Screen.MessageConsole.PrintMessage("Switch has been set to " + Value);
+			Screen.MessageConsole.PrintMessageWithTimeout("Switch has been set to " + Value, TimeoutMessage.GENERAL_TIMEOUT);
         }
     }
 }

--- a/src/Entities/TrapChest.cs
+++ b/src/Entities/TrapChest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ShadowsOfShadows.Consoles;
 using ShadowsOfShadows.Renderables;
 using ShadowsOfShadows.Items;
 
@@ -24,7 +25,7 @@ namespace ShadowsOfShadows.Entities
             {
                 Active = false;
                 Screen.MainConsole.Player.TakeDamage(Damage);
-                Screen.MessageConsole.PrintMessage("It's a trap!");
+                Screen.MessageConsole.PrintMessageWithTimeout("It's a trap!", TimeoutMessage.SHORT_TIMEOUT);
             }
 
             base.Interact();


### PR DESCRIPTION
Można teraz tworzyć wiadomości, które same znikają i podczas których można się poruszać. Jeśli będzie potrzeba to w przyszłości dodamy jeszcze blokujące timeouty.

Resolves #56 